### PR TITLE
Fix build workflow error

### DIFF
--- a/src/main/docker/Dockerfile.multistage
+++ b/src/main/docker/Dockerfile.multistage
@@ -1,5 +1,5 @@
 ## Stage 1 : build with maven builder image with native capabilities - Quinoa will bake in the front-end
-FROM quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java17 AS build
+FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.1-jdk-21 AS build
 COPY --chown=quarkus:quarkus mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn
 COPY --chown=quarkus:quarkus pom.xml /code/


### PR DESCRIPTION
Error displays as "org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported type java.util.JapaneseImperialCalendar is reachable". Solution put forward by Quarkus team is to use Mandrel 23.1 or GraalVM for JDK 21 with Quarkus 3.5. This changes the build image used for the multistage Dockerfile.